### PR TITLE
fix: remove rocq-prover from the dev Dockerfile

### DIFF
--- a/rocq/dev/Dockerfile
+++ b/rocq/dev/Dockerfile
@@ -20,7 +20,6 @@ RUN set -x \
   && opam update -y -u \
   && opam pin add -n -y -k git rocq-runtime.${ROCQ_VERSION} "git+https://github.com/coq/coq#${ROCQ_COMMIT}" \
   && opam pin add -n -y -k git rocq-core.${ROCQ_VERSION} "git+https://github.com/coq/coq#${ROCQ_COMMIT}" \
-  && opam pin add -n -y -k git rocq-prover.${ROCQ_VERSION} "git+https://github.com/coq/coq#${ROCQ_COMMIT}" \
   && opam pin add -n -y -k git coqide-server.${ROCQ_VERSION} "git+https://github.com/coq/coq#${ROCQ_COMMIT}" \
   && opam pin add -n -y -k git coq-core.${ROCQ_VERSION} "git+https://github.com/coq/coq#${ROCQ_COMMIT}" \
   && opam pin add -n -y -k git coq.${ROCQ_VERSION} "git+https://github.com/coq/coq#${ROCQ_COMMIT}" \


### PR DESCRIPTION
Following its removal from core-dev in https://github.com/rocq-prover/opam/pull/3465.

Should fix the currently broken pipelines.

Locally tested by @ybertot.